### PR TITLE
Move basic auth to env variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ function passwordProtected(req, res, next) {
     res.set('WWW-Authenticate', 'Basic realm="Simple Todo App"')
     console.log(req.headers.authorization)
     // only if credentials match.
-    if(req.headers.authorization == "Basic amF2YXNjcmlwdDpwcm9qZWN0") {
+    if(req.headers.authorization == process.env.BASIC_AUTH) {
         // next function to run, only IF is true.
         next()
     } else {


### PR DESCRIPTION
Consider creating an environment variable in Heroku for BASIC_AUTH with an updated username/password.

Current implementation allows someone to take the basic auth token from code and directly pass it as Authorization header to gain access to the app without knowing the username/password.